### PR TITLE
Improve wsdl path finding

### DIFF
--- a/djautotask/__init__.py
+++ b/djautotask/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (0, 0, 11, 'alpha')
+VERSION = (0, 0, 12, 'alpha')
 
 # pragma: no cover
 if VERSION[-1] != "final":

--- a/djautotask/__init__.py
+++ b/djautotask/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (0, 0, 12, 'alpha')
+VERSION = (0, 0, 13, 'alpha')
 
 # pragma: no cover
 if VERSION[-1] != "final":

--- a/djautotask/tests/fixture_utils.py
+++ b/djautotask/tests/fixture_utils.py
@@ -1,19 +1,18 @@
 from suds.client import Client
 from atws.wrapper import QueryCursor
 from atws import helpers
-import urllib
 from xml.etree import ElementTree
-import os
 from djautotask import sync
 from djautotask.tests import mocks, fixtures
+from pathlib import Path
 
 
 def init_api_client():
     # Access the Autotask API's WSDL file from the tests directory
     # so that we can generate mock objects from the API without actually
     # calling the API.
-    path = os.path.abspath("djautotask/tests/atws.wsdl")
-    url = urllib.parse.urljoin('file:', urllib.request.pathname2url(path))
+    path = Path(__file__).parent / 'atws.wsdl'
+    url = 'file://{}'.format(str(path))
 
     return Client(url)
 


### PR DESCRIPTION
Added a small improvement to building the path for the wsdl. This way we can use it from the main app for easily generating test AT objects.