### PR TITLE
Fix use of settings

### DIFF
--- a/djautotask/__init__.py
+++ b/djautotask/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-VERSION = (1, 5, 3, 'final')
+VERSION = (1, 5, 4, 'final')
 
 # pragma: no cover
 if VERSION[-1] != "final":


### PR DESCRIPTION
This removes the use of `settings.AUTOTASK_CREDENTIALS['username']` in `_get_connection_url` so we can use this in projects that don't use the same settings setup as our main app.