### PR TITLE
Support Python 3.14 and Django 6.0

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,17 +20,17 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.14'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r requirements.txt
           pip install --upgrade -r requirements_test.txt
-          python setup.py install
+          pip install .
       - name: Run tests
         run: |
           flake8 .

--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,17 @@ coverage: ## check code coverage quickly with the default Python
 	coverage report -m
 
 install: clean
-	python setup.py install
+	pip install .
 
 lint: ## check style with flake8
 	# flake8 config file at tox.ini
 	flake8 .
 
 test: clean lint
-	python setup.py test
+	python runtests.py
 
 sdist: test
-	python setup.py sdist
+	python -m build --sdist
 
 upload: sdist
     # You must have a ~/.pypirc file with your username and password.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ resources, accounts, etc.).
 
 ## Requirements
 
--  Python 3.5
--  Django 2.0
+-  Python 3.12, 3.13 or 3.14
+-  Django 4.2, 5.2 or 6.0
+-  PostgreSQL (the models declare `GinIndex` indexes)
 
 Other versions may work; we haven't tried.
 
@@ -16,7 +17,7 @@ From source:
 
     git clone git@github.com:KerkhoffTechnologies/django-autotask.git
     cd django-autotask
-    python setup.py install
+    pip install .
 
 ## Usage
 
@@ -26,9 +27,14 @@ From source:
     INSTALLED_APPS = [
         ...
         'djautotask',
+        'django.contrib.postgres',
         ...
     ]
     ```
+
+    `django.contrib.postgres` is required: our models declare `GinIndex`
+    indexes, and as of Django 6.0 the `postgres.E005` system check fails
+    if the app is not installed.
 
 
 ## Testing
@@ -40,7 +46,6 @@ pip install --upgrade -r requirements_test.txt
 Try one of:
 
     ./runtests.py
-    python setup.py test
     make test
 
 ## Contributing

--- a/djautotask/__init__.py
+++ b/djautotask/__init__.py
@@ -2,5 +2,3 @@
 from importlib.metadata import version
 
 __version__ = version("django-autotask")
-
-default_app_config = 'djautotask.apps.DjangoAutotaskConfig'

--- a/djautotask/api.py
+++ b/djautotask/api.py
@@ -4,7 +4,6 @@ import json
 import logging
 from json import JSONDecodeError
 
-import pytz
 import requests
 from django.apps import apps
 from django.conf import settings
@@ -402,7 +401,7 @@ class AutotaskAPIClient(object):
         if isinstance(value, datetime.datetime):
             body.update({
                 key: value.astimezone(
-                    pytz.timezone('UTC')).strftime(
+                    datetime.timezone.utc).strftime(
                     "%Y-%m-%dT%H:%M:%SZ")
             })
 

--- a/djautotask/apps.py
+++ b/djautotask/apps.py
@@ -3,3 +3,8 @@ from django.apps import AppConfig
 
 class DjangoAutotaskConfig(AppConfig):
     name = 'djautotask'
+    # Django 6.0 changed the DEFAULT_AUTO_FIELD default from AutoField to
+    # BigAutoField. Our models and their migrations were built with AutoField,
+    # so pin it here: otherwise every project installing this app would get a
+    # spurious migration altering the primary key of every model.
+    default_auto_field = 'django.db.models.AutoField'

--- a/djautotask/models.py
+++ b/djautotask/models.py
@@ -1,4 +1,4 @@
-import pytz
+from zoneinfo import ZoneInfo
 
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
@@ -870,9 +870,8 @@ class TimeEntry(TimeStampedModel):
         else:
             # Autotask gives us date_worked as a datetime, even though the
             # time is always set to EST midnight (00:00:00).
-            # TODO timezone.pytz does not exist anymore
             est_offset = timezone.localtime(
-                timezone=pytz.timezone(OFFSET_TIMEZONE)).utcoffset()
+                timezone=ZoneInfo(OFFSET_TIMEZONE)).utcoffset()
             local_offset = timezone.localtime().utcoffset()
 
             # We want to end up with a UTC datetime that is midnight in the

--- a/djautotask/tests/mocks.py
+++ b/djautotask/tests/mocks.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 import json
 import responses
 

--- a/djautotask/tests/test_api.py
+++ b/djautotask/tests/test_api.py
@@ -1,9 +1,10 @@
+import datetime
+
 import responses
 import requests
 
 from django.core.cache import cache
 from django.test import TestCase
-from django.utils import timezone
 
 from . import mocks as mk
 
@@ -30,8 +31,8 @@ class TestApiConditionList(TestCase):
         self.assertEqual(filters, None)
 
     def test_build_query_string_multiple_post(self):
-        test_datetime = timezone.datetime(2019, 6, 22, 2, 0, 0,
-                                          tzinfo=timezone.utc)
+        test_datetime = datetime.datetime(2019, 6, 22, 2, 0, 0,
+                                          tzinfo=datetime.timezone.utc)
 
         c = A(
             A(op='eq', field='isActive', value='true'),

--- a/djautotask/tests/test_model.py
+++ b/djautotask/tests/test_model.py
@@ -1,9 +1,9 @@
-import pytz
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 from django.utils import timezone
 from django.test import override_settings
-from datetime import timedelta
+from datetime import timedelta, timezone as datetime_timezone
 
 from djautotask.models import TimeEntry, OFFSET_TIMEZONE
 
@@ -28,20 +28,20 @@ class TestTimeEntry(TestCase):
         gets converted to UTC 05:00:00.
         """
         midnight_est = timezone.localtime(
-            timezone=pytz.timezone(OFFSET_TIMEZONE)
+            timezone=ZoneInfo(OFFSET_TIMEZONE)
         ).replace(
             year=local_midnight.year,
             month=local_midnight.month, day=local_midnight.day,
             hour=0, minute=0, second=0, microsecond=0
         )
         # Convert to UTC just like Django does when we receive Autotask data.
-        date_worked = midnight_est.astimezone(pytz.utc)
+        date_worked = midnight_est.astimezone(datetime_timezone.utc)
         time_entry = TimeEntry()
         time_entry.date_worked = date_worked
 
         # Convert our local datetime to UTC since that is
         # what get_entered_time returns.
-        local_midnight_utc = local_midnight.astimezone(pytz.utc)
+        local_midnight_utc = local_midnight.astimezone(datetime_timezone.utc)
         self.assertEqual(time_entry.get_entered_time(), local_midnight_utc)
 
     @override_settings(TIME_ZONE='America/Vancouver')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
 requests
-django
+django>=4.2
 python-dateutil
 django-model-utils
 django-braces
 django-extensions
 retrying
 wheel
-pytz
 build==1.2.2.post1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
-coverage==4.3
+coverage
 flake8>=2.1.0
-mock==4.0.3
 responses
-model-mommy
-django-coverage
-names
+# django.contrib.postgres must be in INSTALLED_APPS for the GinIndex system
+# check (postgres.E005, added in Django 6.0), and importing that app needs a
+# psycopg driver even though the tests themselves run on sqlite.
+psycopg[binary]

--- a/runtests.py
+++ b/runtests.py
@@ -4,7 +4,6 @@ import sys
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test.utils import get_runner
 import django
 import tempfile
 
@@ -21,6 +20,9 @@ settings.configure(
         'django.contrib.contenttypes',
         'django.contrib.auth',
         'django.contrib.sessions',
+        # Required as of Django 6.0 by the postgres.E005 system check,
+        # because our models declare GinIndex indexes.
+        'django.contrib.postgres',
     ),
     SECRET_KEY='correct horse battery staple',
     AUTOTASK_SERVER_URL='https://localhost',
@@ -86,15 +88,6 @@ def flake8_main():
 
     print("Failed: flake8 failed." if command else "Success. flake8 passed.")
     return command
-
-
-def suite():
-    """
-    Set up and return a test suite. This is used in `python setup.py test`.
-    """
-    _setup()
-    runner_cls = get_runner(settings)
-    return runner_cls().build_suite(test_labels=None)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = (1, 16, 0)
+VERSION = (1, 17, 0)
 
 project_version = '.'.join(map(str, VERSION))
 
@@ -24,21 +24,15 @@ setup(
     url="https://github.com/KerkhoffTechnologies/django-autotask",
     include_package_data=True,
     license='MIT',
+    python_requires='>=3.12',
     install_requires=[
         'requests',
-        'django',
+        'django>=4.2',
         'python-dateutil',
         'django-model-utils',
         'django-braces',
         'django-extensions',
         'retrying',
-    ],
-    test_suite='runtests.suite',
-    tests_require=[
-        'responses',
-        'model-mommy',
-        'django-coverage',
-        'names'
     ],
     # Django likes to inspect apps for /migrations directories, and can't if
     # package is installed as a egg. zip_safe=False disables installation as
@@ -47,11 +41,17 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
+        'Framework :: Django :: 6.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Development Status :: 1 - Planning',

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,3 @@
 [flake8]
 # Migrations are auto-generated (mostly); let's not worry about them.
-exclude = djautotask/tests/fixtures.py,djautotask/migrations/,build,djautotask/tests/mommy_recipes.py,.eggs/
+exclude = djautotask/tests/fixtures.py,djautotask/migrations/,build,.eggs/


### PR DESCRIPTION
Tests and flake8 pass on Python 3.14 with Django 6.0, and remain green on Django 5.2 and 4.2 (Python 3.12).

Breakages fixed:

- pytz: Django dropped pytz support in 5.0. Replaced with stdlib zoneinfo / datetime.timezone.utc.
- django.utils.timezone.utc: removed in Django 5.0.
- GinIndex now requires 'django.contrib.postgres' in INSTALLED_APPS (postgres.E005, new in Django 6.0). This is a breaking change for consumers -- documented in the README. Importing that app needs a psycopg driver, so psycopg[binary] is now a test dependency even though the tests run on sqlite.
- DEFAULT_AUTO_FIELD: Django 6.0 changed the default from AutoField to BigAutoField, which made makemigrations want to rewrite the primary key of every model. Pinned default_auto_field on the AppConfig to preserve the existing schema; moving to BigAutoField should be a deliberate data migration, not a side effect of this upgrade.

Also:

- python setup.py test/install were removed from setuptools, so test_suite, tests_require, the suite() helper, the Makefile targets and the CI step were all dead. Use pip install . / runtests.py / python -m build instead.
- CI: Python 3.8 -> 3.14, actions v3 -> v4/v5.
- Drop unused test deps (model-mommy, django-coverage, names; mommy_recipes.py no longer exists), unpin coverage==4.3 (2017, will not build on 3.14), use stdlib unittest.mock over the mock backport.
- Remove default_app_config, a no-op since Django 4.1.
- Bump version to 1.17.0.