### PR TITLE
4773 keep a project's completed tickets and tasks while the project is open

### DIFF
--- a/djautotask/sync.py
+++ b/djautotask/sync.py
@@ -878,6 +878,19 @@ class ResourceRoleDepartmentSynchronizer(Synchronizer):
         return instance
 
 
+def open_project_ids(order_by='id'):
+    """
+    IDs of the projects that are still open.
+
+    A project's children are kept for as long as the project itself is open,
+    so both the task and the ticket sync scope their retention to this set.
+    """
+    return models.Project.objects.exclude(
+        Q(status__is_active=False) |
+        Q(status__id=models.ProjectStatus.COMPLETE_ID)
+    ).values_list('id', flat=True).order_by(order_by)
+
+
 class CompletedDateMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -950,6 +963,63 @@ class TicketSynchronizer(CreateRecordMixin,
 
         if condition_list:
             self.client.add_condition(A(*condition_list, op="or"))
+
+    def get(self, results):
+        results = super().get(results)
+
+        if self.full:
+            results = self._fetch_open_project_tickets(results)
+
+        return results
+
+    def _fetch_open_project_tickets(self, results):
+        """
+        Second pass: fetch the completed tickets of every open project.
+
+        Autotask lets a project carry tickets as well as tasks, but the main
+        pass drops any ticket completed longer ago than keep_completed_hours,
+        so a project's completed tickets disappear from its child counts
+        while the project is still running. Fetching every completed ticket
+        ever is unbounded, so scope to the open projects already stored
+        locally.
+
+        Deliberately no date floor: the point is to recover tickets that were
+        pruned long ago, not just the recent ones. Their IDs join
+        results.synced_ids, so the prune that follows a full sync leaves them
+        alone. Once the project itself closes it drops out of this set and
+        its tickets become prunable again.
+        """
+        project_ids = list(open_project_ids())
+        if not project_ids:
+            return results
+
+        batch_size = DjautotaskSettings().get_settings().get(
+            'batch_query_size')
+        saved_conditions = self.client.get_conditions()
+
+        try:
+            while project_ids:
+                batch = project_ids[:batch_size]
+                del project_ids[:batch_size]
+
+                # Rebuild from scratch rather than editing the live condition
+                # list, so the completed-date condition is gone for this pass.
+                # The queue filter is re-applied so we don't sync tickets from
+                # queues the tenant excluded.
+                self.client.clear_conditions()
+                self._add_conditions()
+                self.client.add_condition(
+                    A(op='in', field='projectID', value=batch)
+                )
+                self.client.add_condition(
+                    A(op='eq', field='status',
+                      value=models.Status.COMPLETE_ID)
+                )
+                results = self.fetch_records(results)
+        finally:
+            self.client.conditions = saved_conditions
+
+        return results
 
     related_meta = {
         'companyID': (models.Account, 'account'),
@@ -1095,11 +1165,14 @@ class TicketSynchronizer(CreateRecordMixin,
 
 
 class TaskSynchronizer(ChildCreateRecordMixin, SyncRecordUDFMixin,
-                       CompletedDateMixin, BatchQueryMixin, Synchronizer):
+                       BatchQueryMixin, Synchronizer):
+    # No CompletedDateMixin: the query is already scoped to open projects
+    # through active_ids, and a project's completed tasks have to stay for as
+    # long as the project runs or its child counts go wrong. Tasks of closed
+    # projects still fall out of active_ids and get pruned as before.
     client_class = api.TasksAPIClient
     model_class = models.TaskTracker
     udf_class = models.TaskUDF
-    completed_date_field = 'completedDateTime'
     condition_field_name = 'projectId'
     last_updated_field = 'lastActivityDateTime'
 
@@ -1136,12 +1209,7 @@ class TaskSynchronizer(ChildCreateRecordMixin, SyncRecordUDFMixin,
 
     @property
     def active_ids(self):
-        active_projects = models.Project.objects.exclude(
-            Q(status__is_active=False) |
-            Q(status__id=models.ProjectStatus.COMPLETE_ID)
-        ).values_list('id', flat=True).order_by(self.lookup_key)
-
-        return active_projects
+        return open_project_ids(order_by=self.lookup_key)
 
     def _assign_field_data(self, instance, json_data):
         instance.id = json_data['id']

--- a/djautotask/tests/test_sync.py
+++ b/djautotask/tests/test_sync.py
@@ -1481,3 +1481,97 @@ class TestTaskPredecessorSynchronizer(SynchronizerTestMixin, TestCase):
                          object_data['predecessorTaskID'])
         self.assertEqual(instance.successor_task.id,
                          object_data['successorTaskID'])
+
+
+class TestProjectChildRetention(TestCase):
+    """
+    A project's completed children are kept for as long as the project runs.
+    """
+
+    def setUp(self):
+        super().setUp()
+        fixture_utils.init_project_statuses()
+        fixture_utils.init_statuses()
+        fixture_utils.init_accounts()
+        fixture_utils.init_projects()
+
+    def _condition_fields(self, client):
+        """Every field named anywhere in the client's conditions."""
+        fields = []
+
+        def walk(condition):
+            formatted = condition.format_condition()
+            if 'items' in formatted:
+                for item in condition._items:
+                    walk(item)
+            else:
+                fields.append(formatted['field'])
+
+        for condition in client.get_conditions():
+            walk(condition)
+
+        return fields
+
+    def test_open_project_ids_excludes_closed_projects(self):
+        project = models.Project.objects.first()
+        self.assertIn(project.id, list(sync.open_project_ids()))
+
+        project.status = models.ProjectStatus.objects.get(
+            id=models.ProjectStatus.COMPLETE_ID)
+        project.save()
+
+        self.assertNotIn(project.id, list(sync.open_project_ids()))
+
+    def test_task_sync_does_not_filter_on_completed_date(self):
+        # The task query is already scoped to open projects, so filtering on
+        # completion date would drop a running project's finished tasks.
+        synchronizer = sync.TaskSynchronizer(full=True)
+
+        self.assertNotIn(
+            'completedDateTime', self._condition_fields(synchronizer.client))
+
+    def test_task_sync_is_scoped_to_open_projects(self):
+        synchronizer = sync.TaskSynchronizer(full=True)
+
+        self.assertIn('projectId', self._condition_fields(synchronizer.client))
+
+    def test_ticket_full_sync_fetches_open_projects_completed_tickets(self):
+        synchronizer = sync.TicketSynchronizer(full=True)
+        passes = []
+
+        def record_conditions(results):
+            passes.append(self._condition_fields(synchronizer.client))
+            return results
+
+        synchronizer.fetch_records = record_conditions
+        synchronizer.get(SyncResults())
+
+        # First pass is the ordinary ticket sync, second is the retention pass.
+        self.assertEqual(len(passes), 2)
+        retention_pass = passes[1]
+        self.assertIn('projectID', retention_pass)
+        self.assertIn('status', retention_pass)
+        # No date floor: the point is to recover tickets pruned long ago.
+        self.assertNotIn('completedDate', retention_pass)
+
+    def test_ticket_partial_sync_skips_the_retention_pass(self):
+        synchronizer = sync.TicketSynchronizer(full=False)
+        passes = []
+
+        def record_conditions(results):
+            passes.append(self._condition_fields(synchronizer.client))
+            return results
+
+        synchronizer.fetch_records = record_conditions
+        synchronizer.get(SyncResults())
+
+        self.assertEqual(len(passes), 1)
+
+    def test_ticket_retention_pass_restores_original_conditions(self):
+        synchronizer = sync.TicketSynchronizer(full=True)
+        before = self._condition_fields(synchronizer.client)
+
+        synchronizer.fetch_records = lambda results: results
+        synchronizer.get(SyncResults())
+
+        self.assertEqual(self._condition_fields(synchronizer.client), before)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = (1, 17, 0)
+VERSION = (1, 18, 0)
 
 project_version = '.'.join(map(str, VERSION))
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = (1, 18, 0)
+VERSION = (1, 19, 0)
 
 project_version = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
Part of [#4773](https://gitlab.com/topleft.team/apps/django-topleft/-/issues/4773).

## Problem

Autotask lets a project carry tasks *and* tickets (`Task.project`, `Ticket.project`), and both were pruned out from under Project Health:

- **Tasks** were filtered by `keep_completed_hours` (8h) even though their query is already scoped to open projects — the date filter only ever removed work that still mattered.
- **Project tickets** were dropped by the same window, with nothing scoping them to projects at all (`TicketSynchronizer` is the global ticket sync).

There's no retention job to change — a full sync deletes whatever it didn't see, so the sync conditions *are* the retention policy.

## Change

**Tasks** — drop `CompletedDateMixin` from `TaskSynchronizer`; `active_ids` already restricts to open projects. Tasks of closed projects still fall out of `active_ids` and get pruned as before.

**Tickets** — a second pass over the open projects, fetching completed tickets with **no date floor**. The floor is what separates retaining from here on from recovering what was pruned months ago. A full sync re-creates whatever the API returns and PSA IDs are our primary keys, so pruned rows return with their original IDs — no backfill script. Their IDs join `synced_ids`, so the following prune leaves them alone. The queue filter is re-applied so the pass doesn't widen the tenant's queue scope.

Once a project closes it drops out of the set and its children become prunable again (closed projects are #4791).

## Verification

Autotask sandbox, before and after a full sync:

| | before | after |
|---|---|---|
| tasks on open projects | 199 | 272 |
| **completed** tasks | **0** | **75** |
| deleted | — | **0** |

Zero completed children across all 37 open projects — `(total − open) / total` could only read 0%. Per project:

| project | before | after |
|---|---|---|
| KTI- New Employee Set Up | 0/11 | 11/11 |
| Backup and DR Solution | 0/10 | 10/10 |
| Financial System Implementation | 0/18 | 26/49 |
| M365 Implementation | 0/16 | 5/19 |

Two were finished and reporting as untouched. A partial sync alone moved completed tasks 0 → 46 (removing the mixin unfilters partial fetches too); the full sync did the retroactive 46 → 75.

**Caveat:** the ticket half created 0 rows — the sandbox holds one project-attached ticket, not completed. Verified by request shape (`projectID in (…) AND status = 5`, no `completedDate`) and unit tests, not recovered rows. Worth re-running against a tenant with real project tickets.

6 new tests in `TestProjectChildRetention`: no `completedDateTime` filter on tasks, open-project scoping, full-sync pass conditions (including the absent date floor), partial sync skipping the pass, and conditions restored afterward. Suite 379 → 385.

## Notes

- Needs a companion TopLeft change: the AT health strategy counted tasks only, so retaining project tickets does nothing without it.
- First full sync after deploy is a one-shot backfill; watch duration and rate limits. Both synchronizers sit in the `partial` and `operational` grades, so it rides the operational grade — no manual trigger needed.

Version bumped to 1.18.0.
