### PR TITLE
Assign sync relations by ID rather than fetching the related row

### DIFF
--- a/djautotask/sync.py
+++ b/djautotask/sync.py
@@ -255,6 +255,13 @@ class Synchronizer:
         self.mass_delete_protection = request_settings.get(
             'mass_delete_protection', True)
 
+        # Memo of which related primary keys exist, keyed by model class, for
+        # the life of this synchronizer. A page of records refers to the same
+        # handful of queues, statuses and resources over and over, so the first
+        # record pays for the lookup and the rest are free. Its size is bounded
+        # by the number of distinct PKs actually referenced, not by table size.
+        self._related_pk_cache = {}
+
     def set_relations(self, instance, json_data):
         for json_field, value in self.related_meta.items():
             model_class, field_name = value
@@ -284,6 +291,18 @@ class Synchronizer:
                 format(model_field, instance)
             )
 
+    def _related_pk_exists(self, model_class, uid):
+        """
+        Say whether a related record exists, remembering the answer.
+
+        Uses an existence query rather than fetching the row: we only need to
+        know the target is there, and `exists()` builds no model instance.
+        """
+        cache = self._related_pk_cache.setdefault(model_class, {})
+        if uid not in cache:
+            cache[uid] = model_class.objects.filter(pk=uid).exists()
+        return cache[uid]
+
     def _assign_relation(self, instance, json_data,
                          json_field, model_class, model_field):
         """
@@ -292,13 +311,21 @@ class Synchronizer:
         """
         uid = json_data.get(json_field)
 
-        try:
-            if uid is not None and uid != '':
-                related_instance = model_class.objects.get(pk=uid)
-                setattr(instance, model_field, related_instance)
-            else:
-                self._assign_null_relation(instance, model_field)
-        except model_class.DoesNotExist:
+        if uid is None or uid == '':
+            self._assign_null_relation(instance, model_field)
+            return
+
+        field = instance._meta.get_field(model_field)
+
+        # Coerce to the primary key's own type. Fetching the row used to do
+        # this implicitly, so a picklist that reports its parent value as a
+        # string still ended up assigning the int the database returned.
+        # Assigning the raw value would leave the FieldTracker comparing '1'
+        # against 1, reporting a change on every sync and rewriting the row
+        # forever.
+        uid = field.target_field.get_prep_value(uid)
+
+        if not self._related_pk_exists(model_class, uid):
             logger.warning(
                 'Failed to find {} {} for {} {}.'.format(
                     json_field,
@@ -308,6 +335,17 @@ class Synchronizer:
                 )
             )
             self._assign_null_relation(instance, model_field)
+            return
+
+        # Assign the relation by ID. Fetching the row to assign it costs a
+        # query, a model instantiation and a FieldTracker setup per foreign key
+        # per record, and nothing downstream reads anything but the primary key
+        # we already have here. Drop whatever Django may have cached for the
+        # field so that a later attribute access doesn't hand back the record
+        # this one replaced.
+        setattr(instance, field.attname, uid)
+        if field.is_cached(instance):
+            field.delete_cached_value(instance)
 
     def _instance_ids(self, filter_params=None):
         # self.lookup_key is used only for json_data. In DB, id is fixed for

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages
 
-VERSION = (1, 17, 0)
+VERSION = (1, 18, 0)
 
 project_version = '.'.join(map(str, VERSION))
 


### PR DESCRIPTION
`_assign_relation` ran `objects.get(pk=uid)` for every FK on every record — a query, a model
instantiation and a FieldTracker setup, to use only the PK we already had. 16 FKs per ticket.
Now assigns the FK id and validates the target with a memoized existence query.

IDs are coerced via `target_field.get_prep_value`. Without it, Autotask picklist values arrive
as strings, so `parent_value_id = '1'` compared unequal to the stored `1` and SubIssueType
rewrote all 33 rows on every sync. Caught by the created/updated/skipped counters.

Measured, same machine, interleaved master/branch/master/branch from an identical dump:

    CPU      16.1 → 11.4 s   (~-29%)  noise floor between identical master runs: 12%
    queries  34,936 → 18,096 (-48%)
    RSS      -0.0%

    TicketSynchronizer alone: 14,674 → 4,623 queries

CPU here is the noisiest of the three PSAs — the sandbox demo data is refreshed by a scheduled
job, so read it as "about 30%". The query delta is solid.

Counters identical across all four samples; no table content differs beyond that drift.

379 tests, flake8 clean.
